### PR TITLE
fix(rm unsupported regex): remove lookbehind op. unsupported in mobile

### DIFF
--- a/src/app/services/generation.service.ts
+++ b/src/app/services/generation.service.ts
@@ -91,16 +91,6 @@ export class GenerationService {
     return { fullDate, weekDay, month, day, year };
   }
 
-  private getSites(html: string) {
-    const siteAbbrs = /(?<=^\s*HR.*)[A-Z]{3}.*?/gm;
-    const sites: string[] = [];
-    let match;
-    while (match = siteAbbrs.exec(html)) {
-      sites.push(match[0])
-    }
-    return sites;
-  }
-
   public isGenerating(genSchedule): boolean {
     const currentHour = (new Date()).getHours();
     return genSchedule[currentHour] > 0;

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -21,10 +21,6 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** Evergreen browsers require these. **/
-// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
-import 'core-js/es6/reflect';
-
 /**
  * Web Animations `@angular/platform-browser/animations`
  * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.


### PR DESCRIPTION
remove unused lookbehind regex operator that unsupported in safari and other mobile browsers. remove unnecessary core-js polyfills